### PR TITLE
Conserve backslashes.

### DIFF
--- a/poorman
+++ b/poorman
@@ -120,7 +120,7 @@ log_line() {
     # Log given line to stdout, prefixed with timestamp & program name.
 
     colored="$POORMAN_LOG_COLOR`date +"%H:%M:%S"` $POORMAN_LOG_PREFIX\033[0m"
-    echo -e "$colored" "$*"
+    echo -e "$colored" "${*//\\/\\\\}"
 }
 
 echo_env_export() {

--- a/poorman
+++ b/poorman
@@ -127,7 +127,7 @@ echo_env_export() {
     # Print eval-able line, intended for use with .env lines.
 
     if [[ "$@" == *=* ]]; then
-        echo "export $@"
+        echo "export ${@//\\/\\\\}"
     fi
 }
 

--- a/poorman
+++ b/poorman
@@ -190,7 +190,7 @@ map_lines() {
 
     IFS="$NEW_IFS"
     local count=0
-    while read line; do
+    while read -r line; do
         IFS="$OLD_IFS"
         $line_function "$line"
         local result=$?

--- a/poorman
+++ b/poorman
@@ -120,6 +120,7 @@ log_line() {
     # Log given line to stdout, prefixed with timestamp & program name.
 
     colored="$POORMAN_LOG_COLOR`date +"%H:%M:%S"` $POORMAN_LOG_PREFIX\033[0m"
+    # Evaluate THESE backslashes, but not THOSE backslashes.
     echo -e "$colored" "${*//\\/\\\\}"
 }
 
@@ -127,7 +128,7 @@ echo_env_export() {
     # Print eval-able line, intended for use with .env lines.
 
     if [[ "$@" == *=* ]]; then
-        echo "export ${@//\\/\\\\}"
+        echo "export ${@//\\/\\\\}"  # <---- Look, mountains!
     fi
 }
 


### PR DESCRIPTION
The following tests work with these changes:
#### Procfile test

```
# Procfile
test: echo \n
```
#### Procfile+.env test

```
# .env
BS=\n

# Procfile
test: echo $BS
```
