### PR TITLE
Skip comments properly.

### DIFF
--- a/poorman
+++ b/poorman
@@ -317,9 +317,8 @@ parse_procfile_line() {
 
     local line="$@"
 
-    line=${line%%\#*} # Strip out comments.
-    if [ -z "$line" ]; then
-        # Line is empty. Ensure values are unset for caller inspection.
+    if [[ "$line" =~ ^\ *# ]]; then
+        # Line is comment only. Ensure values are unset for caller inspection.
         unset $name_var $command_var
         return
     fi

--- a/poorman
+++ b/poorman
@@ -317,7 +317,7 @@ parse_procfile_line() {
 
     local line="$@"
 
-    if [[ "$line" =~ ^\ *# ]]; then
+    if [[ "$line" =~ ^[[:space:]]*# ]]; then
         # Line is comment only. Ensure values are unset for caller inspection.
         unset $name_var $command_var
         return

--- a/test/utility.bats
+++ b/test/utility.bats
@@ -217,6 +217,12 @@ do_parse_procfile_line() {\
     assert_equal "command" "" "${lines[1]}"
 }
 
+@test "parse_procfile_line: comment preceded by tab" {
+    run do_parse_procfile_line "	# this is a comment";
+    assert_equal "name" "" "${lines[0]}"
+    assert_equal "command" "" "${lines[1]}"
+}
+
 @test "parse_procfile_line: statement with comment" {
     run do_parse_procfile_line "foo: echo hello # this is a comment";
     assert_equal "name" "foo" "${lines[0]}"

--- a/test/utility.bats
+++ b/test/utility.bats
@@ -186,3 +186,52 @@ fail_on_two() {
     assert_equal '$DOT' "-" "$DOT"
     unset DOT
 }
+
+do_parse_procfile_line() {\
+    parse_procfile_line NAME COMMAND "$1";
+    echo $NAME
+    echo $COMMAND
+}
+
+@test "parse_procfile_line: statement" {
+    run do_parse_procfile_line "foo: echo bar"
+    assert_equal "name" "foo" "${lines[0]}"
+    assert_equal "command" "echo bar" "${lines[1]}"
+}
+
+@test "parse_procfile_line: blank line" {
+    run do_parse_procfile_line ""
+    assert_equal "name" "" "${lines[0]}"
+    assert_equal "command" "" "${lines[1]}"
+}
+
+@test "parse_procfile_line: whitespace-only line" {
+    run do_parse_procfile_line "   "
+    assert_equal "name" "" "${lines[0]}"
+    assert_equal "command" "" "${lines[1]}"
+}
+
+@test "parse_procfile_line: comment" {
+    run do_parse_procfile_line "    # this is a comment";
+    assert_equal "name" "" "${lines[0]}"
+    assert_equal "command" "" "${lines[1]}"
+}
+
+@test "parse_procfile_line: statement with comment" {
+    run do_parse_procfile_line "foo: echo hello # this is a comment";
+    assert_equal "name" "foo" "${lines[0]}"
+    assert_equal "command" "echo hello # this is a comment" "${lines[1]}"
+}
+
+@test "parse_procfile_line: statement with hash in quotes" {
+    run do_parse_procfile_line "foo: echo '#hello'";
+    assert_equal "name" "foo" "${lines[0]}"
+    assert_equal "command" "echo '#hello'" "${lines[1]}"
+}
+
+@test "parse_procfile_line: statement with hash in expression" {
+    run do_parse_procfile_line 'foo: echo ${0##*/}: There are $# arguments';
+    assert_equal "name" "foo" "${lines[0]}"
+    assert_equal "command" 'echo ${0##*/}: There are $# arguments' "${lines[1]}"
+}
+


### PR DESCRIPTION
@rduplain Is there any reason not to just use a regex for the comment test? This patch will skip a line if the first non-space character is `#`.